### PR TITLE
[GROW-3134] release already acquired connections, when get_connections raised an exception

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2026,6 +2026,8 @@ class ClusterPipeline(RedisCluster):
                     try:
                         connection = get_connection(redis_node, c.args)
                     except (ConnectionError, TimeoutError) as e:
+                        for n in nodes.values():
+                            n.connection_pool.release(n.connection)
                         if self.retry and isinstance(e, self.retry._supported_errors):
                             backoff = self.retry._backoff.compute(attempts_count)
                             if backoff > 0:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -12,6 +12,7 @@ from unittest.mock import DEFAULT, Mock, call, patch
 
 import pytest
 
+import redis.cluster
 from redis import Redis
 from redis.backoff import (
     ConstantBackoff,
@@ -3047,6 +3048,32 @@ class TestClusterPipeline:
             assert first_node.redis_connection.connection.read_response.called
             assert ask_node.redis_connection.connection.read_response.called
             assert res == ["MOCK_OK"]
+
+    @pytest.mark.parametrize("error", [ConnectionError, TimeoutError])
+    def test_return_previous_acquired_connections(self, r, error):
+        # in order to ensure that a pipeline will make use of connections
+        #   from different nodes
+        assert r.keyslot('a') != r.keyslot('b')
+
+        orig_func = redis.cluster.get_connection
+        with patch("redis.cluster.get_connection") as get_connection:
+            def raise_error(target_node, *args, **kwargs):
+                if get_connection.call_count == 2:
+                    raise error("mocked error")
+                else:
+                    return orig_func(target_node, *args, **kwargs)
+
+            get_connection.side_effect = raise_error
+
+            r.pipeline().get('a').get('b').execute()
+
+        # there should have been two get_connections per execution and
+        #   two executions due to exception raised in the first execution
+        assert get_connection.call_count == 4
+        for cluster_node in r.nodes_manager.nodes_cache.values():
+            connection_pool = cluster_node.redis_connection.connection_pool
+            num_of_conns = len(connection_pool._available_connections)
+            assert num_of_conns == connection_pool._created_connections
 
     def test_empty_stack(self, r):
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3053,10 +3053,11 @@ class TestClusterPipeline:
     def test_return_previous_acquired_connections(self, r, error):
         # in order to ensure that a pipeline will make use of connections
         #   from different nodes
-        assert r.keyslot('a') != r.keyslot('b')
+        assert r.keyslot("a") != r.keyslot("b")
 
         orig_func = redis.cluster.get_connection
         with patch("redis.cluster.get_connection") as get_connection:
+
             def raise_error(target_node, *args, **kwargs):
                 if get_connection.call_count == 2:
                     raise error("mocked error")
@@ -3065,7 +3066,7 @@ class TestClusterPipeline:
 
             get_connection.side_effect = raise_error
 
-            r.pipeline().get('a').get('b').execute()
+            r.pipeline().get("a").get("b").execute()
 
         # there should have been two get_connections per execution and
         #   two executions due to exception raised in the first execution


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
when writing test for a custom patch that we've made, i found out that we may be leaking connections in the below scenario
```
scenario:
1. pipeline needs to be executed on multiple nodes (node 1 and node2)
2. obtain a connection for node 1
3. failed to obtain a connection for node 2 due to ConnectionError or TimeoutError
4. repeat 2 and 3 until it succeeds
```

In the above scenario, the connection on node 1 that we've acquired doesn't get released forever as we lose reference to the connection, when an exception is raised

FYI there may be more connection leaks, but we need to monitor after this gets applied

_Please provide a description of the change here._
