### PR TITLE
[GROW-3361] always release, instead of disconnect, when error occurs during get_connection

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2162,6 +2162,8 @@ class ClusterPipeline(RedisCluster):
                 if n.connection:
                     n.connection.disconnect()
                     n.connection_pool.release(n.connection)
+            if len(nodes) > 0:
+                time.sleep(0.25)
             raise
 
     def _fail_on_redirect(self, allow_redirections):

--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -1103,7 +1103,7 @@ class RedisCluster(AbstractRedisCluster, RedisClusterCommands):
                     # The nodes and slots cache were reinitialized.
                     # Try again with the new cluster setup.
                     retry_attempts -= 1
-                    if self.retry and isinstance(e, self.retry._supported_errors):
+                    if self.retry and self.retry.is_supported_error(e):
                         backoff = self.retry._backoff.compute(
                             self.cluster_error_retry_attempts - retry_attempts
                         )
@@ -2039,9 +2039,7 @@ class ClusterPipeline(RedisCluster):
                                 n.connection_pool.release(n.connection)
                                 n.connection = None
                             nodes = {}
-                            if self.retry and isinstance(
-                                e, self.retry._supported_errors
-                            ):
+                            if self.retry and self.retry.is_supported_error(e):
                                 backoff = self.retry._backoff.compute(attempts_count)
                                 if backoff > 0:
                                     time.sleep(backoff)

--- a/redis/retry.py
+++ b/redis/retry.py
@@ -32,6 +32,9 @@ class Retry:
             set(self._supported_errors + tuple(specified_errors))
         )
 
+    def is_supported_error(self, error):
+        return isinstance(error, self._supported_errors)
+
     def call_with_retry(self, do, fail):
         """
         Execute an operation that might fail and returns its result, or

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2805,8 +2805,10 @@ class TestClusterPipeline:
 
             m.side_effect = raise_error
 
-            with pytest.raises(Exception, match="unexpected error"):
-                r.pipeline().get("a").execute()
+            with patch.object(Connection, "disconnect") as d:
+                with pytest.raises(Exception, match="unexpected error"):
+                    r.pipeline().get("a").execute()
+                assert d.call_count == 1
 
         for cluster_node in r.nodes_manager.nodes_cache.values():
             connection_pool = cluster_node.redis_connection.connection_pool
@@ -3127,7 +3129,7 @@ class TestClusterPipeline:
             assert res == ["MOCK_OK"]
 
     @pytest.mark.parametrize("error", [ConnectionError, TimeoutError])
-    def test_return_previous_acquired_connections(self, r, error):
+    def test_return_previous_acquired_connections_with_retry(self, r, error):
         # in order to ensure that a pipeline will make use of connections
         #   from different nodes
         assert r.keyslot("a") != r.keyslot("b")
@@ -3143,7 +3145,13 @@ class TestClusterPipeline:
 
             get_connection.side_effect = raise_error
 
-            r.pipeline().get("a").get("b").execute()
+            with patch.object(NodesManager, "initialize") as i:
+                # in order to remove disconnect caused by initialize
+                i.side_effect = lambda: None
+
+                with patch.object(Connection, "disconnect") as d:
+                    r.pipeline().get("a").get("b").execute()
+                    assert d.call_count == 0
 
         # there should have been two get_connections per execution and
         #   two executions due to exception raised in the first execution
@@ -3152,6 +3160,39 @@ class TestClusterPipeline:
             connection_pool = cluster_node.redis_connection.connection_pool
             num_of_conns = len(connection_pool._available_connections)
             assert num_of_conns == connection_pool._created_connections
+
+    @pytest.mark.parametrize("error", [RedisClusterException, BaseException])
+    def test_return_previous_acquired_connections_without_retry(self, r, error):
+        # in order to ensure that a pipeline will make use of connections
+        #   from different nodes
+        assert r.keyslot("a") != r.keyslot("b")
+
+        orig_func = redis.cluster.get_connection
+        with patch("redis.cluster.get_connection") as get_connection:
+
+            def raise_error(target_node, *args, **kwargs):
+                if get_connection.call_count == 2:
+                    raise error("mocked error")
+                else:
+                    return orig_func(target_node, *args, **kwargs)
+
+            get_connection.side_effect = raise_error
+
+            with patch.object(Connection, "disconnect") as d:
+                with pytest.raises(error):
+                    r.pipeline().get("a").get("b").execute()
+                assert d.call_count == 0
+
+        # there should have been two get_connections per execution and
+        #   two executions due to exception raised in the first execution
+        assert get_connection.call_count == 2
+        for cluster_node in r.nodes_manager.nodes_cache.values():
+            connection_pool = cluster_node.redis_connection.connection_pool
+            num_of_conns = len(connection_pool._available_connections)
+            assert num_of_conns == connection_pool._created_connections
+            # connection must remain connected
+            for conn in connection_pool._available_connections:
+                assert conn._sock is not None
 
     def test_empty_stack(self, r):
         """

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -9,6 +9,8 @@ from redis.exceptions import (
     BusyLoadingError,
     ConnectionError,
     ReadOnlyError,
+    RedisClusterException,
+    RedisError,
     TimeoutError,
 )
 from redis.retry import Retry
@@ -121,6 +123,16 @@ class TestRetry:
 
         assert self.actual_attempts == 5
         assert self.actual_failures == 5
+
+    @pytest.mark.parametrize("exception_class", [ConnectionError, TimeoutError])
+    def test_is_supported_error_true(self, exception_class):
+        retry = Retry(BackoffMock(), -1)
+        assert retry.is_supported_error(exception_class())
+
+    @pytest.mark.parametrize("exception_class", [RedisClusterException, RedisError])
+    def test_is_supported_error_false(self, exception_class):
+        retry = Retry(BackoffMock(), -1)
+        assert not retry.is_supported_error(exception_class())
 
 
 @pytest.mark.onlynoncluster


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
`gevent.Timeout` used to cause a connection leak, but that was patched with #8.

Now, i want to make sure that connections are not disconnected so often, so this PR makes any error from `get_connection` to always release a connection without disconnection. Disconnection is only necessary, when a connection is reading or writing, but `get_connection` is neither of those

additional changes:
- `isinstance(e, self.retry._supported_errors)` is lengthy, so i've also created a `is_supported_error` function to shorten the code
- add a static backoff, when we need to disconnect connections due to unforeseen exceptions
  - backoff from retry is not used, because it's not a retriable exception
  - similar to https://github.com/redis/redis-py/blob/6968431983c20a6f874a97d92c4d11366721b83b/redis/cluster.py#L1198