### PR TITLE
[GROW-3262] add __repr__ to RedisCluster objects

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2341,6 +2341,16 @@ class PipelineCommand:
         self.node = None
         self.asking = False
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}<"
+            f"args={repr(self.args)},"
+            f"options={repr(self.options)},"
+            f"position={self.position},"
+            f"result={repr(self.result)}"
+            ">"
+        )
+
 
 class NodeCommands:
     """ """
@@ -2351,6 +2361,14 @@ class NodeCommands:
         self.connection_pool = connection_pool
         self.connection = connection
         self.commands = []
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}<"
+            f"connection={repr(self.connection)},"
+            f"commands={repr(self.commands)}"
+            ">"
+        )
 
     def append(self, c):
         """ """


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
when looking through sentry, it's hard to debug redis-py related issues, because object is not represented well. This PR added `__repr__` method to NodeCommands and PipelineCommand to show data on sentry

current:
![image](https://github.com/sendbird/redis-py/assets/109944297/f97b26c3-93d6-42ce-8851-a18c5ab6279e)

with this PR:
![image](https://github.com/sendbird/redis-py/assets/109944297/0460411f-5af2-43b9-ad8d-efb0ec3c78ba)

