### PR TITLE
add support for timeout argument in RedisCluster

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -157,6 +157,7 @@ REDIS_ALLOWED_KEYS = (
     "ssl_cert_reqs",
     "ssl_keyfile",
     "ssl_password",
+    "timeout",  # added timeout to support injecting BlockingConnectionPool timeout
     "unix_socket_path",
     "username",
 )


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
I've forgot to port the change i've implemented to redis-py
https://github.com/sendbird/soda/pull/16439
