### PR TITLE
Batch SSUBSCRIBE by Redis Cluster slot to avoid CROSSSLOT errors and improve efficiency

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1682,7 +1682,7 @@ class PubSub:
             channels_by_slot[slot].append(channel)
 
         slot_count = len(channels_by_slot)
-        min_interval_ms = 100
+        min_interval_ms = 25
         base_interval_ms = max(60_000 / slot_count, min_interval_ms)
 
         for slot, channels in channels_by_slot.items():

--- a/redis/client.py
+++ b/redis/client.py
@@ -1682,8 +1682,8 @@ class PubSub:
             channels_by_slot[slot].append(channel)
 
         slot_count = len(channels_by_slot)
-        min_interval_ms = 25
-        base_interval_ms = max(60_000 / slot_count, min_interval_ms)
+        min_interval_ms = 10
+        base_interval_ms = max(30_000 / slot_count, min_interval_ms)
 
         for slot, channels in channels_by_slot.items():
             self.execute_command("SSUBSCRIBE", *channels)


### PR DESCRIPTION
…ered bursts

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR changes how `SSUBSCRIBE` commands are issued in Redis Cluster mode.

Previously, each channel was subscribed individually in a loop, resulting in one `SSUBSCRIBE` per channel. In Redis Cluster, this increases the risk of CROSSSLOT errors and introduces unnecessary overhead when multiple channels belong to the same hash slot.

This update improves the logic by **grouping channels by their Redis hash slot**, and **sending a single `SSUBSCRIBE` per slot group**, subscribing to all relevant channels at once.

### Motivation

- Redis Cluster requires that all keys in a multi-key command reside in the same hash slot.  
  Subscribing to multiple channels across slots in a single command causes `CROSSSLOT` errors.
- The previous implementation avoided this by sending individual commands per channel, but this is inefficient.
- Batching subscriptions by slot reduces command overhead and aligns with Redis Cluster's intended usage pattern.

### Changes

- Group channels by their hash slot (`key_slot(self.encoder.encode(channel))`)
- Issue one `SSUBSCRIBE` command per slot group (i.e., `SSUBSCRIBE channel1 channel2 ...`)
- Add minor jitter between slot-level subscription requests to avoid synchronized load (±30%)

### Example

```python
channels_by_slot = defaultdict(list)
for channel in new_s_channels:
    slot = key_slot(self.encoder.encode(channel))
    channels_by_slot[slot].append(channel)

for slot, channels in channels_by_slot.items():
    self.execute_command("SSUBSCRIBE", *channels)
    time.sleep(base_interval * random.uniform(0.7, 1.3))
