### PR TITLE
Batch SSUBSCRIBE by Redis Cluster slot to avoid CROSSSLOT errors

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -4,6 +4,7 @@ import re
 import threading
 import time
 import warnings
+from collections import defaultdict
 from itertools import chain
 from typing import Optional
 
@@ -14,6 +15,7 @@ from redis.commands import (
     list_or_args,
 )
 from redis.connection import ConnectionPool, SSLConnection, UnixDomainSocketConnection
+from redis.crc import key_slot
 from redis.credentials import CredentialProvider
 from redis.exceptions import (
     ConnectionError,
@@ -1447,11 +1449,14 @@ class PubSub:
             }
             self.psubscribe(**patterns)
         if self.shard_channels:
-            shard_channels = {
-                self.encoder.decode(k, force=True): v
-                for k, v in self.shard_channels.items()
-            }
-            self.ssubscribe(**shard_channels)
+            channels_by_slot = defaultdict(dict)
+            for k, v in self.shard_channels.items():
+                key = self.encoder.decode(k, force=True)
+                slot = key_slot(self.encoder.encode(key))
+                channels_by_slot[slot][key] = v
+
+            for slot, channels in channels_by_slot.items():
+                self.ssubscribe(**channels)
 
     @property
     def subscribed(self):
@@ -1672,8 +1677,8 @@ class PubSub:
             args = list_or_args(args[0], args[1:])
         new_s_channels = dict.fromkeys(args)
         new_s_channels.update(kwargs)
-        for channel in new_s_channels:  # We should send ssubscribe one by one on redis cluster to prevent CROSSSLOT error
-            self.execute_command("SSUBSCRIBE", channel)
+        ret_val = self.execute_command("SSUBSCRIBE", *new_s_channels.keys())
+
         # update the s_channels dict AFTER we send the command. we don't want to
         # subscribe twice to these channels, once for the command and again
         # for the reconnection.
@@ -1685,6 +1690,7 @@ class PubSub:
             # Clear the health check counter
             self.health_check_response_counter = 0
         self.pending_unsubscribe_shard_channels.difference_update(new_s_channels)
+        return ret_val
 
     def sunsubscribe(self, *args, target_node=None):
         """


### PR DESCRIPTION
…ered bursts

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `$ tox` pass with this change (including linting)?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR changes how `SSUBSCRIBE` commands are issued in Redis Cluster mode.

Previously, each channel was subscribed individually in a loop, resulting in one `SSUBSCRIBE` per channel. In Redis Cluster, this increases the risk of CROSSSLOT errors and introduces unnecessary overhead when multiple channels belong to the same hash slot.

This update improves the logic by **grouping channels by their Redis hash slot**, and **sending a single `SSUBSCRIBE` per slot group**, subscribing to all relevant channels at once.

### Motivation

- Redis Cluster requires that all keys in a multi-key command reside in the same hash slot.  
  Subscribing to multiple channels across slots in a single command causes `CROSSSLOT` errors.
- The previous implementation avoided this by sending individual commands per channel, but this is inefficient.
- Batching subscriptions by slot reduces command overhead and aligns with Redis Cluster's intended usage pattern.

### Changes

- Group channels by their hash slot (`key_slot(self.encoder.encode(channel))`)
- Issue one `SSUBSCRIBE` command per slot group (i.e., `SSUBSCRIBE channel1 channel2 ...`)

### Example

```python
channels_by_slot = defaultdict(list)
for channel in new_s_channels:
    slot = key_slot(self.encoder.encode(channel))
    channels_by_slot[slot].append(channel)
```